### PR TITLE
Proposals for reservation procedure

### DIFF
--- a/tasks/presentation.md
+++ b/tasks/presentation.md
@@ -38,9 +38,11 @@ The whole list of appropriate topics can be found [here](presentation-topics.md)
 If you decide to perform online, you automatically agree, that your performance could be recorded and added to RS  
 School YouTube channel. Video will be _unlisted_ — it means, that only people with direct link would have access to it.
 
-You understand that, once you have reserved a slot in the timesheet, you take on the responsibility for appearing and performing according to the date and time chosen, unless instructed otherwise by the jury or school administration. You also agree that you must specify your up-to-date contact details and monitor the relevant announcements in the school's channels, otherwise the jury shall be entitled to remove you from the list of presenters without any obligation to notify.
+You understand that, once you have reserved a slot in the timesheet, you take on the responsibility for appearing and performing according to the date and time chosen, unless instructed otherwise by the jury or school administration. If you have a reasonable excuse not to attend, you must notify the jury thereof no later than 24 hours prior to the presentation session. You also agree that you must specify your up-to-date contact details and monitor the relevant announcements in the school's channels, otherwise the jury shall be entitled to remove you from the list of presenters without any obligation to notify.
 
 The consequences of the failure to comply with the above rules may result in a penalty of up to 30 points.
+
+If any time slots become available, students may reserve those for their presentations on a first-come, first-served basis.
 
   
 ## Useful links:

--- a/tasks/presentation.md
+++ b/tasks/presentation.md
@@ -38,11 +38,11 @@ The whole list of appropriate topics can be found [here](presentation-topics.md)
 If you decide to perform online, you automatically agree, that your performance could be recorded and added to RS  
 School YouTube channel. Video will be _unlisted_ — it means, that only people with direct link would have access to it.
 
-You understand that, once you have reserved a slot in the timesheet, you take on the responsibility for appearing and performing according to the date and time chosen, unless instructed otherwise by the jury or school administration. You can cancel the reservation without any consequences whatsoever having notified the jury no later than 24 hours prior to the presentation session. If you have a reasonable excuse not to attend, notify the jury anyway as soon as it is practically possible. You also agree that you must specify your up-to-date contact details and monitor the relevant announcements in the school's channels, otherwise the jury shall be entitled to remove you from the list of presenters without any obligation to notify.
+You understand that, once you have reserved a slot in the timesheet, you take on the responsibility for appearing and performing according to the date and time chosen, unless instructed otherwise by the jury or school administration. You can cancel the reservation without any consequences whatsoever by removing your name from the list no later than **24 hours** prior to the presentation **session**. If you have a reasonable excuse not to attend, notify the jury anyway as soon as it is practically possible. You also agree that you must specify your up-to-date contact details and monitor the relevant announcements in the school's channels, otherwise the jury shall be entitled to remove you from the list of presenters without any obligation to notify.
 
 The consequences of the failure to comply with the above rules may result in a penalty of up to **30 points**.
 
-If any time slots become available, students may reserve those for their presentations on a first-come, first-served basis.
+If any time slots become available, students may reserve those for their presentations on a **first-come, first-served** basis.
 
   
 ## Useful links:

--- a/tasks/presentation.md
+++ b/tasks/presentation.md
@@ -37,6 +37,11 @@ The whole list of appropriate topics can be found [here](presentation-topics.md)
 **❗️ Important:**  
 If you decide to perform online, you automatically agree, that your performance could be recorded and added to RS  
 School YouTube channel. Video will be _unlisted_ — it means, that only people with direct link would have access to it.
+
+You understand that, once you have reserved a slot in the timesheet, you take on the responsibility for appearing and performing according to the date and time chosen, unless instructed otherwise by the jury or school administration. You also agree that you must specify your up-to-date contact details and monitor the relevant announcements in the school's channels, otherwise the jury shall be entitled to remove you from the list of presenters without any obligation to notify.
+
+The consequences of the failure to comply with the above rules may result in a penalty of up to 30 points.
+
   
 ## Useful links:
 * http://speaking.io/

--- a/tasks/presentation.md
+++ b/tasks/presentation.md
@@ -38,9 +38,9 @@ The whole list of appropriate topics can be found [here](presentation-topics.md)
 If you decide to perform online, you automatically agree, that your performance could be recorded and added to RS  
 School YouTube channel. Video will be _unlisted_ — it means, that only people with direct link would have access to it.
 
-You understand that, once you have reserved a slot in the timesheet, you take on the responsibility for appearing and performing according to the date and time chosen, unless instructed otherwise by the jury or school administration. If you have a reasonable excuse not to attend, you must notify the jury thereof no later than 24 hours prior to the presentation session. You also agree that you must specify your up-to-date contact details and monitor the relevant announcements in the school's channels, otherwise the jury shall be entitled to remove you from the list of presenters without any obligation to notify.
+You understand that, once you have reserved a slot in the timesheet, you take on the responsibility for appearing and performing according to the date and time chosen, unless instructed otherwise by the jury or school administration. You can cancel the reservation without any consequences whatsoever having notified the jury no later than 24 hours prior to the presentation session. If you have a reasonable excuse not to attend, notify the jury anyway as soon as it is practically possible. You also agree that you must specify your up-to-date contact details and monitor the relevant announcements in the school's channels, otherwise the jury shall be entitled to remove you from the list of presenters without any obligation to notify.
 
-The consequences of the failure to comply with the above rules may result in a penalty of up to 30 points.
+The consequences of the failure to comply with the above rules may result in a penalty of up to **30 points**.
 
 If any time slots become available, students may reserve those for their presentations on a first-come, first-served basis.
 


### PR DESCRIPTION
There's a considerable number of students who reserve slots for live presentation, but fail to appear and notify in advance, thereby forfeiting chances of those students who were too late to reserve slots. Also, many students don't provide any contact details, thus making it impossible for the jury to reach them.