### PR TITLE
Tweak README of stage1/modules/data-structures

### DIFF
--- a/stage1/modules/data-structures/README.md
+++ b/stage1/modules/data-structures/README.md
@@ -29,8 +29,9 @@
 Вам необходимо пройти тест "Test Algorithms & Data structures" в RS APP > Auto Test
 
 Задачи:  
-- [Задачи: "basic-js"](https://github.com/AlreadyBored/basic-js)
 - [Задачи: "basic-js-ds"](https://github.com/AlreadyBored/basic-js-ds)
+- [Задачи: "basic-js"](https://github.com/AlreadyBored/basic-js)
+    - Выполните столько, сколько успеете.
 
 ## Дополнительные материалы
 1. Больше методов массива: [видео на YouTube](https://youtu.be/d8c-JgbpMHs), [документация MDN](https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/Array)


### PR DESCRIPTION
Изменение: поменять местами пункты выполнения задач `basic-js` и `basic-js-ds` и добавить к первому подпункт, подчёркивающий тот факт, что от судентов не ожидается выполнение всех задач.

Когда я проходил модуль, то заметил за собой и другими студентами, что многие занимались именно `basic-js` и не прикоснулись к `basic-js-ds` из-за большого количества задач (многие из которых сложные) в первом. Из-за порядка пунктов можно подумать, что `basic-js` должен выполняться первым, но `basic-js-ds` намного легче и короче, и за оба набора задач даётся одинаковое количество баллов.

Так как многие не успевают выполнить первый набор задач, из-за чего не прикосаются ко второму, и чтобы подчеркнуть дух необязательности выполнения большого количества задач первого набора, я предлагаю поменять их местами и добавить подпункт, чтобы люди в первую очередь пощупали код, связанный с темой структур данных, и потом выполняли столько алгоритмических задач, сколько могли.