### PR TITLE
Feat(migration-to-ts): add ESLint 'no-explicit-any' rule to cross-check requirements

### DIFF
--- a/tasks/migration-newip-to-ts.md
+++ b/tasks/migration-newip-to-ts.md
@@ -95,7 +95,7 @@
      - использование Object Types +10
      - использование Classes +10
      - использование Function +10
-   - ESLinter настроен на TypeScript и отсутствуют ошибки +10
+   - ESLinter настроен на TypeScript, включено правило `no-explicit-any` и отсутствуют ошибки +10
    - нигде не используется тип Any +10
    - В конфигурационном файле TypeScript стоят флаги `"noImplicitAny": true` и `"strict": true` + 20
    - webpack настроен и работает с TypeScript +10
@@ -108,7 +108,8 @@
 
 1. Используется тип Any -20
 2. Код не полностью покрыт типами -20
-3. В конфигурационном файле TypeScript не стоят обязательные флаги `"noImplicitAny": true` и `"strict": true` - 20
+3. В конфигурационном файле TypeScript не стоят обязательные флаги `"noImplicitAny": true` и `"strict": true` -20
+4. В конфигурационном файле ESLint не включено правило `no-explicit-any` -10
 
 ## Требования к репозиторию
 


### PR DESCRIPTION
Using ESLint 'no-explicit-any' rule is a technical requirement in this task, but it's not checking in cross-check requirements. So I decided to add it to cross-check requirements and penalties.
Please have a look and consider merging PR.