### PR TITLE
Исправление в пример из задачи на interview-coreJS

### DIFF
--- a/tasks/interview-corejs.md
+++ b/tasks/interview-corejs.md
@@ -264,4 +264,4 @@
 - `periodOutput(period)` method should output in the console once per every period how mach time has passed since the first function call.
   Example:
   `periodOutput(100) -> 100(after 100 ms), 200(after 100 ms), 300(after 100 ms), ...`
-- `extendedPeriodOutput(period)` method should output in the console once per period how mach time has passed since the first function call and then increase the period. Example: `// extendedPeriodOutput(100) -> 100(after 100 ms), 200(after 200 ms), 300(after 300 ms)`
+- `extendedPeriodOutput(period)` method should output in the console once per period how mach time has passed since the first function call and then increase the period. Example: `// extendedPeriodOutput(100) -> 100(after 100 ms), 300(after 200 ms), 600(after 300 ms)`


### PR DESCRIPTION
Пример в задаче **extendedPeriodOutput(period)** не совпадает с условием. Если мы последовательно увеличиваем интервал на 100, и при этом считаем все время, прошедшее с момента вызова функции, то соотношение времени/интервала должно быть "100 after 100ms, 300 after 200ms, 600 after 300ms, 1000 after 400ms " и т.д.