### PR TITLE
fix: update how to install node.js link

### DIFF
--- a/node/modules/nodejs-installation/README.md
+++ b/node/modules/nodejs-installation/README.md
@@ -10,5 +10,5 @@
 3 hours
 
 ## Theory
-- [How to install Node.js](https://nodejs.dev/learn/how-to-install-nodejs)
+- [How to install Node.js](https://nodejs.dev/en/learn/how-to-install-nodejs)
 - [nvm docs](https://github.com/nvm-sh/nvm#intro)


### PR DESCRIPTION
The link [https://nodejs.dev/learn/how-to-install-nodejs](https://nodejs.dev/learn/how-to-install-nodejs) is no longer available.
Replaced by the correct one: [https://nodejs.dev/**_en_**/learn/how-to-install-nodejs](https://nodejs.dev/en/learn/how-to-install-nodejs)