### PR TITLE
Add closing details tag after RSClones list

### DIFF
--- a/tasks/rsclone/rsclone.md
+++ b/tasks/rsclone/rsclone.md
@@ -249,6 +249,8 @@ RS Clone - это командное задание, в ходе выполне�
 - [Amazing Trip](https://shipu4ka-rs-clone.netlify.app/)
 - [Telegram](https://telegram-rs-clone.netlify.app/)
 
+</details>
+
 <details><summary> 2022Q1 </summary>
 
 **Приложения:**

--- a/tasks/rsclone/rsclone.md
+++ b/tasks/rsclone/rsclone.md
@@ -237,7 +237,7 @@ RS Clone - это командное задание, в ходе выполне�
 - [Blazing](https://blazing-8s-rs.netlify.app/)
 - [Battle Ships](https://battle-ships-pwrrngrs.netlify.app/)
 
-**Apps**
+**Applications**
 
 - [RS Doctors](https://alienteam-rsdoctors.netlify.app/)
 - [Fintess X](https://elijah-i.github.io/RS-clone/)

--- a/tasks/rsclone/rsclone.md
+++ b/tasks/rsclone/rsclone.md
@@ -237,7 +237,7 @@ RS Clone - это командное задание, в ходе выполне�
 - [Blazing](https://blazing-8s-rs.netlify.app/)
 - [Battle Ships](https://battle-ships-pwrrngrs.netlify.app/)
 
-**Applications**
+**Apps**
 
 - [RS Doctors](https://alienteam-rsdoctors.netlify.app/)
 - [Fintess X](https://elijah-i.github.io/RS-clone/)


### PR DESCRIPTION
hey there o/
just noticed - forgot closing 'details' tag after games list for 2022q3 examples and all the previous went into the same drop down list

now:
![image](https://user-images.githubusercontent.com/101958335/227641451-4305a8c6-0f53-4bf8-819e-749b9d0e82d4.png)
will be as should:
![image](https://user-images.githubusercontent.com/101958335/227641849-a9086317-6235-4de9-8113-94cc16823b3f.png)

ty <3

task: https://github.com/rolling-scopes-school/tasks/blob/master/tasks/rsclone/rsclone.md