### PR TITLE
docs: change documentation link

### DIFF
--- a/stage2/modules/testing/README.md
+++ b/stage2/modules/testing/README.md
@@ -17,11 +17,11 @@
 2 часа
 
 ## Теория 
-- https://doka.guide/js/how-to-test-and-why/
-- https://doka.guide/js/tdd/
-- https://doka.guide/js/how-to-simplify-tests/
-- https://doka.guide/js/testing-and-fake-objects/
-- https://doka.guide/js/integration-and-system-testing/
+- https://doka.guide/tools/how-to-test-and-why/
+- https://doka.guide/tools/tdd/
+- https://doka.guide/tools/how-to-simplify-tests/
+- https://doka.guide/tools/testing-and-fake-objects/
+- https://doka.guide/tools/integration-and-system-testing/
 
 
 ## Практика 


### PR DESCRIPTION
https://github.com/rolling-scopes-school/tasks/tree/master/stage2/modules/testing
![image](https://github.com/rolling-scopes-school/tasks/assets/66093034/b2217e2e-2cc5-42b5-85e2-059ad53d4719)

Change links to the documentation. The previous version leads to not-found page