### PR TITLE
stage#2 - Async Race - Change link to repo requirements

### DIFF
--- a/tasks/async-race.md
+++ b/tasks/async-race.md
@@ -60,7 +60,7 @@ What are you waiting for? Let's coding!
 - (**+5**) Code shouldn't contain magical numbers or strings.
 
 ## Requirements to commits, PR and repo
-[Stage 2 requirements](https://docs.app.rs.school/#/platform/pull-request-review-process)
+[Stage 2 requirements](https://docs.rs.school/#/en/pull-request-review-process)
 
 ## Key skills
 - Сommunication with a server (fetch, REST API)

--- a/tasks/async-race.md
+++ b/tasks/async-race.md
@@ -61,6 +61,7 @@ What are you waiting for? Let's coding!
 
 ## Requirements to commits, PR and repo
 [Stage 2 requirements](https://docs.rs.school/#/en/pull-request-review-process)
+NB: for mentor's check - submit link to PR, for cross-check - submit link to deploy.
 
 ## Key skills
 - Сommunication with a server (fetch, REST API)


### PR DESCRIPTION
hey there o/
changed link to https://docs.rs.school/#/en/pull-request-review-process
that insists to complete stage#2 tasks in school's private repos, unless otherwise specified in a task
plus reminder to submit pr for mentor's check and deploy for cross-check