### PR TITLE
docs: react module#1 - replace the item about run test with run prettier

### DIFF
--- a/react/modules/module01/README.md
+++ b/react/modules/module01/README.md
@@ -50,7 +50,7 @@ The task will be checked during cross-check and cross-code-review.
 1. Clone the repository you are going to review
 2. Install all the required dependencies
 3. Run linting using special command in package.json file, output should not produce any errors or warnings
-4. Run tests using special command in package.json file, all tests should pass, test coverage should be shown after running all the tests
+4. Run prettier using special command in package.json file, make sure that fix commands fixes issues
 5. Review the code. Pay attention at the following "code smells":
    - props drilling;
    - large, complex components aka "god" components;


### PR DESCRIPTION
Short description: since the writing of tests will begin only in module 3, there is no need for this point of the [Cross-code-review process](https://github.com/rolling-scopes-school/tasks/tree/master/react/modules/module01#cross-code-review-process): 
 - Run tests using special command in package.json file, all tests should pass, test coverage should be shown after running all the tests.
 
This item can be replaced with it:
 - Run prettier using special command in package.json file, make sure that fix commands fixes issues
