### PR TITLE
docs: update react-components config

### DIFF
--- a/react/modules/module01/configs.md
+++ b/react/modules/module01/configs.md
@@ -27,8 +27,7 @@ Might be insignificantly changed
   "extends": [
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended",
-    "prettier",
-    "plugin:prettier/recommended"
+    "prettier"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
@@ -105,7 +104,6 @@ Might be insignificantly changed
     "moduleResolution": "Node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noImplicitAny": true,
     "noEmit": true,
     "jsx": "react-jsx"
   },


### PR DESCRIPTION
удалил plugin:prettier/recommended из extends (из-за которого на текущий момент ошибка)

убрал флаг noImplicitAny в тс конфиге, так как strict: true автоматически активирует noImplicitAny