### PR TITLE
fix: module functions stage1

### DIFF
--- a/stage1/modules/functions/README.md
+++ b/stage1/modules/functions/README.md
@@ -17,7 +17,7 @@ Scope
 - [Call/Apply/Bind](https://www.freecodecamp.org/news/understand-call-apply-and-bind-in-javascript-with-examples/)
 - [Static and Dynamic Scope](https://benmyers.dev/blog/scope/#lexical-scope-versus-dynamic-scope)
 - [Closures](https://benmyers.dev/blog/scope/#closures)
-- [Closures and Loops](https://www.geeksforgeeks.org/concept-of-javascript-closures-inside-loops/)
+- [Closures and Loops](https://www.freecodecamp.org/news/thrown-for-a-loop-understanding-for-loops-and-timeouts-in-javascript-558d8255d8a4)
 - [Chaining](https://www.geeksforgeeks.org/method-chaining-in-javascript/)
 - [Decorator](https://javascript.info/call-apply-decorators)
 - Scheduling


### PR DESCRIPTION
The [previous link](https://www.geeksforgeeks.org/concept-of-javascript-closures-inside-loops/) to Closures and Loops has been corrected due to errors in it.

This is an example from that link and it will cause difficulties for students:
![image](https://github.com/rolling-scopes-school/tasks/assets/88070488/01dca171-0a8e-4805-8811-e50ed0045ed5)

But the result of the code execution will be:
![image](https://github.com/rolling-scopes-school/tasks/assets/88070488/7c0ea8ab-ff74-4217-a9d7-d38db8a09ca8)

The mistake is related with **var** and **let**.
Students will face the same two questions in the test with var and let.

I suppose that the [new link](https://www.freecodecamp.org/news/thrown-for-a-loop-understanding-for-loops-and-timeouts-in-javascript-558d8255d8a4) added in PR is more correct. For example, here are the correct explanation for the same function: 

![image](https://github.com/rolling-scopes-school/tasks/assets/88070488/07e364a8-a3e2-48cb-a8eb-0977d85c043f)
-----------------
And correct explanation for the function with var:

![image](https://github.com/rolling-scopes-school/tasks/assets/88070488/4a30ab4f-9bd1-4f9a-abe2-0ae4427a6ed6)
