### PR TITLE
fix: rename stage1 module link

### DIFF
--- a/stage1/README.md
+++ b/stage1/README.md
@@ -113,7 +113,7 @@
 
 - Modules:
 
-  - [Module: "Adaptive layout markup"](modules/responsive-web-design/)
+  - [Module: "Responsive Web Design"](modules/responsive-web-design/)
   - [Module: "Media Queries"](modules/media-queries/)
 
 - Tasks:


### PR DESCRIPTION
Renamed the module link in the Stage1 Readme file from "Adaptive layout markup" to "Responsive Web Design" to match the module title.