### PR TITLE
Angular: Proposal to make final project in private repos

### DIFF
--- a/tasks/connections/README.md
+++ b/tasks/connections/README.md
@@ -59,7 +59,7 @@ of `Default`.
 
 As a result application is supposed to use real backend and be deployed to any public host-provider
 to make your project reachable. Also, the source of your project should be pushed to your private
-repository to allow any other student check it out.
+repository to allow any other students check it out.
 NB: make repository public right before the cross-check and submit link to the PR (from development
 branch to main) in the Cross-Check Submit in RSApp.
 Pull Request should follow guideline (including checkboxes in Score) [PR example](https://docs.rs.school/#/en/pull-request-review-process?id=pull-request-description-must-contain-the-following).

--- a/tasks/connections/README.md
+++ b/tasks/connections/README.md
@@ -58,8 +58,11 @@ We encourage you to use `ChangeDetectionStrategy.OnPush` strategy in components 
 of `Default`.
 
 As a result application is supposed to use real backend and be deployed to any public host-provider
-to make your project reachable. Also, the source of your project should be pushed to school
+to make your project reachable. Also, the source of your project should be pushed to your private
 repository to allow any other student check it out.
+NB: make repository public right before the cross-check and submit link to the PR (from development
+branch to main) in the Cross-Check Submit in RSApp.
+Pull Request should follow guideline (including checkboxes in Score) [PR example](https://docs.rs.school/#/en/pull-request-review-process?id=pull-request-description-must-contain-the-following).
 
 > [!Warning]
 > In the root README.md file of your project a brief description should be defined what


### PR DESCRIPTION
hey there o/
would be way more convenient to make final project in own private students' repositories - just let's make it public before cross-check, also in school's repos students won't be able to check others' source code and no hassle with pushing/moving existed code, plus this way we submit link to PR in rsapp

- [x] ⚙️ Update to an existing task
- [x] 🐛 Fix in a task or related content

@OlehDulebaEpam take a look at please