### PR TITLE
Big O notation: best case issue in Merge and Quick sort

### DIFF
--- a/stage1/modules/data-structures-and-algorithms/algorithms.md
+++ b/stage1/modules/data-structures-and-algorithms/algorithms.md
@@ -117,7 +117,7 @@ One of the fundamental sorting algorithms.
 
 #### Complexity (Big-O)
 
-- Best case: **O(n)**
+- Best case: **O(n log n)**
 - Average and worst cases: **O(n log n)**
 
 #### Implementation
@@ -157,7 +157,7 @@ Although the Big-O values here are the same as many other sorting algorithms (an
 
 #### Complexity (Big-O)
 
-- Best case: **O(n)**
+- Best case: **O(n log n)**
 - Average case: **O(n log n)**
 - Worst case: **O(n²)**
 


### PR DESCRIPTION
#### Title of Pull Request

Big O notation: fix of quicksort/merge sort best case time complexity

#### 🤔 This is a ...

- [ x ] 🛠 Fix in a module or related content
- [ x ] ✏️ Fixed a typo or grammatical error


#### Description

- **Brief Overview:**

The best case scenario for Merge Sort and QuickSort is O(n log (n)), because both algorithms exploit a strategy called "divide and conquer" efficiently in scenarios where the data is already sorted or nearly sorted. Not O(n).  

We usually say, that In the best-case, worst-case, and average scenarios, Merge Sort requires O(n) additional memory to store temporary arrays for merging. So, I assume the O(n) mentioned in the doc was about it. 


#### Additional Information

- **Screenshots/Links:**
[Merge Sort] (https://big-o.io/algorithms/comparison/merge-sort/)
[Quick Sort] (https://big-o.io/algorithms/comparison/quicksort/)

#### Checklist

- [ x] ✅ I have performed a self-review of my own code.
- [ ] 📝 I have commented my code, particularly in hard-to-understand areas.
- [x ] 🔧 I have made corresponding changes to the documentation (if applicable).
- [ x] 🚫 My changes generate no new warnings or errors.
