### PR TITLE
docs(git): change link to hot generate SSH key

### DIFF
--- a/stage0/modules/git/README.md
+++ b/stage0/modules/git/README.md
@@ -36,7 +36,7 @@
 
 0. [Базовые основы по git, github ( графический интерфейс )](https://www.youtube.com/watch?v=8Dd7KRpKeaE)
 1. [Основы Git. Учебник](https://git-scm.com/book/ru/v2/Введение-О-системе-контроля-версий)
-2. [Инструкция по добавлению SSH в Git](https://github.com/TUstiugov/ssh-hints-for-win/blob/main/ssh-hints-for-win.md)
+2. [Инструкция по добавлению SSH в Git](https://docs.github.com/ru/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
 3. Хорошие материалы от Git-комьюнити в виде документации: https://uleming.github.io/gitbook/index.html
 4. Интерактивный тренажер по Git: https://learngitbranching.js.org/?locale=ru_RU
 5. [Скринкаст по Git (learn.javascript.ru)](https://www.youtube.com/watch?v=W4hoc24K93E&list=PLDyvV36pndZFHXjXuwA_NywNrVQO0aQqb)


### PR DESCRIPTION
#### Title of Pull Request

<!-- ✍️ Provide a concise and informative title for your pull request -->

#### 🤔 This is a ...

- [ ] 🌟 New task
- [ ] 🌐 New module
- [ ] ⚙️ Update to an existing task
- [ ] 🔧 Update to an existing module
- [ ] 🔗 Update or addition of external resources or links
- [ ] 🐛 Fix in a task or related content
- [ ] 🛠 Fix in a module or related content
- [ ] ✏️ Fixed a typo or grammatical error
- [x] 🔗 Fixed a broken link
- [ ] ❓ Other (specify: **\*\*\*\***\_\_\_\_**\*\*\*\***)

#### Description

- **Brief Overview:**
The old link to SSH key generation was broken. I have updated the link to the official guidelines from GitHub.

#### Checklist

- [x] ✅ I have performed a self-review of my own code.
- [x] 📝 I have commented my code, particularly in hard-to-understand areas.
- [x] 🔧 I have made corresponding changes to the documentation (if applicable).
- [x] 🚫 My changes generate no new warnings or errors.
