### PR TITLE
Angular - change broken home page link for train-a project

### DIFF
--- a/tasks/train-a/profile.md
+++ b/tasks/train-a/profile.md
@@ -175,5 +175,5 @@ Page allows authenticated users to view and update their personal information. U
 
 ## Next section
 
-- [Home page](./home.md)
+- [Home page](./search.md)
 - [Manager page](./admin)


### PR DESCRIPTION
hey there o/

currently link from the profile page leads to /.home.md, if i understand correctly - Home page is Search page - so changed link to /.search.md

- [x] 🐞 Fix in a task or related content
