### PR TITLE
[stage-1] reduce interactivity points from 4 to 2 (christmas-shop-part-1 task)

### DIFF
--- a/tasks/christmas-shop/christmas-shop-part1.md
+++ b/tasks/christmas-shop/christmas-shop-part1.md
@@ -4,7 +4,7 @@
 
 - [Detailed Description](christmas-shop.md)
 
-You need to create `Home` and `Gifts` pages according to the [Design in Figma](https://www.figma.com/design/zTB01BwWZVoXYK5atH3eZT/Cristmas-Shop) - only **Home / w1440** and **Gifts / w1440**.  
+You need to create `Home` and `Gifts` pages according to the [Design in Figma](https://www.figma.com/design/zTB01BwWZVoXYK5atH3eZT/Cristmas-Shop) - only **Home / w1440** and **Gifts / w1440**.
 The content width of 1440px should not change when resizing the browser window.
 
 ## Workflow
@@ -56,7 +56,7 @@ The content width of 1440px should not change when resizing the browser window.
    - In the `<footer>`, clicking on the card **MAGIC FOREST** should open a new browser tab with Google Maps displaying any location of your choice: **+2**
    - In the `<footer>`, clicking on the link **Made in Rolling Scopes School** should open the [school's website](https://rs.school/) in a new tab: **+2**
    - Interactivity of the links and buttons is implemented according to the Figma layout. Interactivity includes not only changing cursor's appearance, for example, using the `cursor: pointer` property, but also the use of other visual effects, such as changing the background color or font color, following the **Styleguide** in the Figma layout. If the interactivity is not specified in the **Styleguide**, `cursor: pointer` property is enough: **+4**
-   - Mandatory requirement for interactivity: smooth change in the appearance of an element on hover, without affecting adjacent elements: **+4**
+   - Mandatory requirement for interactivity: smooth change in the appearance of an element on hover, without affecting adjacent elements: **+2**
 
 ### Penalties
 


### PR DESCRIPTION
#### Title of Pull Request

<!-- ✍️ Provide a concise and informative title for your pull request -->

#### 🤔 This is a ...

- [ ] 🌟 New task
- [ ] 🌐 New module
- [ ] ⚙️ Update to an existing task
- [ ] 🔧 Update to an existing module
- [ ] 🔗 Update or addition of external resources or links
- [x] 🐛 Fix in a task or related content
- [ ] 🛠 Fix in a module or related content
- [ ] ✏️ Fixed a typo or grammatical error
- [ ] 🔗 Fixed a broken link
- [ ] ❓ Other (specify: **\*\*\*\***\_\_\_\_**\*\*\*\***)

#### Description

- **Brief Overview:**
In the [Christmas Shop task. Part-1](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/christmas-shop/christmas-shop-part1.md#crosscheck-criteria-110-points) points for the interactivity section were 38 points, instead of 36. Because of this, the total number of points for the task was 112, instead of 110