### PR TITLE
fix: change broken link to alternative

### DIFF
--- a/react/modules/error-boundary/README.md
+++ b/react/modules/error-boundary/README.md
@@ -32,7 +32,7 @@ Students are encouraged to study the following resources:
 2. **Implementing Error Boundaries:**
 
    - [How To Use Error Boundaries in React](https://www.digitalocean.com/community/tutorials/react-error-boundaries) - [15 minutes]
-   - [Handling Errors with Error Boundaries](https://codepen.io/gaearon/pen/wqvxGa?editors=0010) - [15 minutes]
+   - [Handling Errors with Error Boundaries](https://codesandbox.io/p/sandbox/react-16-error-boundaries-forked-vnhng4) - [15 minutes]
 
 ## Additional Resources 📘
 


### PR DESCRIPTION
#### Title of Pull Request

Broken link fix for React Error Boundaries theory module, providing alternative source.

#### 🤔 This is a ...

- [ ] 🌟 New task
- [ ] 🌐 New module
- [ ] ⚙️ Update to an existing task
- [ ] 🔧 Update to an existing module
- [ ] 🔗 Update or addition of external resources or links
- [ ] 🐛 Fix in a task or related content
- [ ] 🛠 Fix in a module or related content
- [ ] ✏️ Fixed a typo or grammatical error
- [x] 🔗 Fixed a broken link
- [ ] ❓ Other (specify: **\*\*\*\***\_\_\_\_**\*\*\*\***)

#### Description

- **Brief Overview:**
Original link to codepen is broken - it returns error 404. New link works.
- **Implementation Approach:**
Since original link is broken, I'm not 100% sure what was there. But based on original URL I managed to find other sources that mention this URL and most likely show original content (see such links below). Based on those sources, offered change provides equivalent alternative to broken link.

#### Additional Information

- **Screenshots/Links:**
- Original broken link: https://codepen.io/gaearon/pen/wqvxGa?editors=0010
- Broken link mentioned together with what's most likely a content of lost link: https://ru.stackoverflow.com/questions/1060595/react-error-boundaries-предохранители-Странное-поведение
- Someone else's sandbox with similar code: https://codesandbox.io/p/sandbox/32eq3q9nr
- [ ] Related Issues:


#### Checklist

- [x] ✅ I have performed a self-review of my own code.
- [ ] 📝 I have commented my code, particularly in hard-to-understand areas.
- [ ] 🔧 I have made corresponding changes to the documentation (if applicable).
- [x] 🚫 My changes generate no new warnings or errors.
