### PR TITLE
docs: change links to ru

### DIFF
--- a/stage2/tasks/TypeScriptEssentials/README.md
+++ b/stage2/tasks/TypeScriptEssentials/README.md
@@ -11,14 +11,14 @@ Dive into the world of TypeScript and enhance your JavaScript skills with this c
 
 ### 📖 Modules to Complete
 
-1. **[Getting Started with TypeScript](https://learn.microsoft.com/en-us/training/modules/typescript-get-started/)**: Discover the basics of TypeScript and understand how it enhances JavaScript development.
-2. **[Declare Variable Types in TypeScript](https://learn.microsoft.com/en-us/training/modules/typescript-declare-variable-types/)**: Learn how to define and use variable types for more robust code.
-3. **[Implement Interfaces in TypeScript](https://learn.microsoft.com/en-us/training/modules/typescript-implement-interfaces/)**: Master the use of interfaces to enforce structure on objects and classes.
-4. **[Develop Typed Functions in TypeScript](https://learn.microsoft.com/en-us/training/modules/typescript-develop-typed-functions/)**: Explore how to create and use typed functions for clearer, more predictable code.
-5. **[Declare and Instantiate Classes in TypeScript](https://learn.microsoft.com/en-us/training/modules/typescript-declare-instantiate-classes/)**: Get hands-on experience with classes, one of the core concepts of TypeScript.
-6. **[Generics in TypeScript](https://learn.microsoft.com/en-us/training/modules/typescript-generics/)**: Understand how to use generics for creating reusable and flexible components.
-7. **[Work with External Libraries in TypeScript](https://learn.microsoft.com/en-us/training/modules/typescript-work-external-libraries/)**: Learn to integrate and utilize external libraries in your TypeScript projects.
-8. **[Organize Code with Namespaces in TypeScript](https://learn.microsoft.com/en-us/training/modules/typescript-namespaces-organize-code/)**: Dive into organizing code effectively using namespaces.
+1. **[Getting Started with TypeScript](https://learn.microsoft.com/ru-ru/training/modules/typescript-get-started/)**: Discover the basics of TypeScript and understand how it enhances JavaScript development.
+2. **[Declare Variable Types in TypeScript](https://learn.microsoft.com/ru-ru/training/modules/typescript-declare-variable-types/)**: Learn how to define and use variable types for more robust code.
+3. **[Implement Interfaces in TypeScript](https://learn.microsoft.com/ru-ru/training/modules/typescript-implement-interfaces/)**: Master the use of interfaces to enforce structure on objects and classes.
+4. **[Develop Typed Functions in TypeScript](https://learn.microsoft.com/ru-ru/training/modules/typescript-develop-typed-functions/)**: Explore how to create and use typed functions for clearer, more predictable code.
+5. **[Declare and Instantiate Classes in TypeScript](https://learn.microsoft.com/ru-ru/training/modules/typescript-declare-instantiate-classes/)**: Get hands-on experience with classes, one of the core concepts of TypeScript.
+6. **[Generics in TypeScript](https://learn.microsoft.com/ru-ru/training/modules/typescript-generics/)**: Understand how to use generics for creating reusable and flexible components.
+7. **[Work with External Libraries in TypeScript](https://learn.microsoft.com/ru-ru/training/modules/typescript-work-external-libraries/)**: Learn to integrate and utilize external libraries in your TypeScript projects.
+8. **[Organize Code with Namespaces in TypeScript](https://learn.microsoft.com/ru-ru/training/modules/typescript-namespaces-organize-code/)**: Dive into organizing code effectively using namespaces.
 
 ### 📝 Task Requirements
 


### PR DESCRIPTION
#### 🤔 This is a ...

- [ ] 🌟 New task
- [ ] 🌐 New module
- [ ] ⚙️ Update to an existing task
- [ ] 🔧 Update to an existing module
- [ ] 🔗 Update or addition of external resources or links
- [ ] 🐛 Fix in a task or related content
- [ ] 🛠 Fix in a module or related content
- [ ] ✏️ Fixed a typo or grammatical error
- [x] 🔗 Fixed a broken link
- [ ] ❓ Other (specify: **\*\*\*\***\_\_\_\_**\*\*\*\***)

#### Description

- **Brief Overview:**
learn.microsoft.com removed the TypeScript course in English, but it is still available in translation. I have updated the links to the available course.