### PR TITLE
docs: fixed the broken link

### DIFF
--- a/tasks/cv/en/cv.md
+++ b/tasks/cv/en/cv.md
@@ -85,7 +85,7 @@ EPAM HR Department Recommendations
 ## Commit Requirements:
 
 - The commit history should reflect the development process of the application.
-- [Use commit names according to the guideline](https://rs.school/docs/en/git-convention)
+- [Use commit names according to the guideline [EN]](https://rs.school/docs/git-convention) / [RU](https://rs.school/ru/docs/git-convention)
 
 ## Pull Request Requirements:
 


### PR DESCRIPTION
This URL returns HTTP status 404:

https://rs.school/docs/en/git-convention

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/75ad65fa-8499-425c-b222-88691e321286" />

I found pages that return HTTP status 200:

en: https://rs.school/docs/git-convention

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/c4bbec9b-aa81-4858-a378-c760774a3611" />

ru: https://rs.school/ru/docs/git-convention

 <img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/ace4118a-86d7-4e1a-9751-fc2924ad10b9" />
