### PR TITLE
docs(christmas-shop): fix swapped path segments in rs.school docs link

### DIFF
--- a/tasks/christmas-shop/christmas-shop-part1.md
+++ b/tasks/christmas-shop/christmas-shop-part1.md
@@ -9,7 +9,7 @@ The content width of 1440px should not change when resizing the browser window.
 
 ## Workflow
 
-1. The task should be completed in private repository of the school. [How to work with a school's private repository](https://rs.school/docs/ru/private-repository)
+1. The task should be completed in private repository of the school. [How to work with a school's private repository](https://rs.school/docs/private-repository)
 2. Create a new branch named `christmas-shop` from `main` branch. Create a folder `christmas-shop` in the created branch. Place your code in this folder.
 3. Complete the task.
 4. Ensure your work meets the [CrossCheck Criteria](#crosscheck-criteria).

--- a/tasks/christmas-shop/christmas-shop-part2.md
+++ b/tasks/christmas-shop/christmas-shop-part2.md
@@ -19,7 +19,7 @@ To make responsive design, use relative units of measurement (%, rem, vh, etc).
 
 ## Workflow
 
-1. The task should be completed in private repository of the school. [How to work with a school's private repository](https://rs.school/docs/ru/private-repository).
+1. The task should be completed in private repository of the school. [How to work with a school's private repository](https://rs.school/docs/private-repository).
 2. Create a new branch named `christmas-shop-part2` from the `christmas-shop` branch. You will find the `christmas-shop` folder containing the project files completed in the previous stage within this branch.
 3. Continue working on the task within the branch you have created.
 4. Ensure your work meets the [CrossCheck Criteria](#crosscheck-criteria).

--- a/tasks/christmas-shop/christmas-shop-part3.md
+++ b/tasks/christmas-shop/christmas-shop-part3.md
@@ -23,7 +23,7 @@ In this part of the task, you need to add the following functionality to the web
 
 ## Workflow
 
-1. The task should be completed in private repository of the school. [How to work with a school's private repository](https://rs.school/docs/ru/private-repository).
+1. The task should be completed in private repository of the school. [How to work with a school's private repository](https://rs.school/docs/private-repository).
 2. Create a new branch named `christmas-shop-part3` from `christmas-shop` branch. You will find the `christmas-shop` folder containing the project files completed in the previous stage within this branch.
 3. Continue working on the task within the branch you have created.
 4. Ensure your work meets the [CrossCheck Criteria](#crosscheck-criteria).


### PR DESCRIPTION
#### Title of Pull Request

Fix incorrect link in the "christmas-shop" to rs.school private repository docs

#### 🤔 This is a

- [ ] 🌟 New task
- [ ] 🌐 New module
- [ ] ⚙️ Update to an existing task
- [ ] 🔧 Update to an existing module
- [ ] 🔗 Update or addition of external resources or links
- [ ] 🐛 Fix in a task or related content
- [ ] 🛠 Fix in a module or related content
- [ ] ✏️ Fixed a typo or grammatical error
- [x] 🔗 Fixed a broken link
- [ ] ❓ Other (specify: **\*\*\*\***\_\_\_\_**\*\*\*\***)

#### Description

- **Brief Overview:**
    Fixed an incorrect URL in christmas-shop. The path segments /ru and /docs 
    were swapped, causing the link to lead to a non-existent page.
- **Implementation Approach:**
    Changed the link from /docs/ru/private-repository
    to the correct /docs/private-repository.

#### Additional Information

- **Screenshots/Links:**
  Correct link: [https://rs.school/docs/private-repository]
- [ ] Related Issues:
<!-- 🔗 Mention any related issues or pull requests if applicable -->

#### Checklist

- [x] ✅ I have performed a self-review of my own code.
- [x] 📝 I have commented my code, particularly in hard-to-understand areas.
- [x] 🔧 I have made corresponding changes to the documentation (if applicable).
- [x] 🚫 My changes generate no new warnings or errors.
