### PR TITLE
docs: update bootcamp handbook links

### DIFF
--- a/stage0.5 Bootcamp/tasks/async-race/README.md
+++ b/stage0.5 Bootcamp/tasks/async-race/README.md
@@ -6,7 +6,7 @@
 
 ## Our Handbook
 
-👉 [Open Handbook](https://publish.obsidian.md/juniornotess/RS-Bootcamp-2026/Tasks/07+%E2%80%94+Async+Race) 👈
+👉 [Open Handbook](https://autocubes.site/junior-notes/rs-bootcamp-2026/readme) 👈
 
 This handbook is currently in a test phase.
 If you notice any issues or have suggestions, feel free to contact me on Discord: `@OreskaG`

--- a/stage0.5 Bootcamp/tasks/css-meme-slider/README.md
+++ b/stage0.5 Bootcamp/tasks/css-meme-slider/README.md
@@ -6,7 +6,7 @@
 
 ## Our Handbook
 
-👉 [Open Handbook](https://publish.obsidian.md/juniornotess/RS-Bootcamp-2026/Tasks/01+%E2%80%94+CSS+Meme+Slider) 👈
+👉 [Open Handbook](https://autocubes.site/junior-notes/rs-bootcamp-2026/readme) 👈
 
 This handbook is currently in a test phase.
 If you notice any issues or have suggestions, feel free to contact me on Discord: `@OreskaG`

--- a/stage0.5 Bootcamp/tasks/html-builder/README.md
+++ b/stage0.5 Bootcamp/tasks/html-builder/README.md
@@ -6,7 +6,7 @@
 
 ## Our Handbook
 
-👉 [Open Handbook](https://publish.obsidian.md/juniornotess/RS-Bootcamp-2026/Tasks/06+%E2%80%94+HTML+Builder) 👈
+👉 [Open Handbook](https://autocubes.site/junior-notes/rs-bootcamp-2026/readme) 👈
 
 This handbook is currently in a test phase.
 If you notice any issues or have suggestions, feel free to contact me on Discord: `@OreskaG`

--- a/stage0.5 Bootcamp/tasks/js30/js30.md
+++ b/stage0.5 Bootcamp/tasks/js30/js30.md
@@ -6,7 +6,7 @@
 
 ## Our Handbook
 
-👉 [Open Handbook](https://publish.obsidian.md/juniornotess/RS-Bootcamp-2026/Tasks/03+%E2%80%94+JS30+Widgets) 👈
+👉 [Open Handbook](https://autocubes.site/junior-notes/rs-bootcamp-2026/readme) 👈
 
 This handbook is currently in a test phase.
 If you notice any issues or have suggestions, feel free to contact me on Discord: `@OreskaG`

--- a/stage0.5 Bootcamp/tasks/notFightClub/README.md
+++ b/stage0.5 Bootcamp/tasks/notFightClub/README.md
@@ -6,7 +6,7 @@
 
 ## Our Handbook
 
-👉 [Open Handbook](https://publish.obsidian.md/juniornotess/RS-Bootcamp-2026/Tasks/05+%E2%80%94+Not+Fight+Club) 👈
+👉 [Open Handbook](https://autocubes.site/junior-notes/rs-bootcamp-2026/readme) 👈
 
 This handbook is currently in a test phase.
 If you notice any issues or have suggestions, feel free to contact me on Discord: `@OreskaG`

--- a/stage0.5 Bootcamp/tasks/podcast-player/README.md
+++ b/stage0.5 Bootcamp/tasks/podcast-player/README.md
@@ -6,7 +6,7 @@
 
 ## Our Handbook
 
-👉 [Open Handbook](https://publish.obsidian.md/juniornotess/RS-Bootcamp-2026/Tasks/04+%E2%80%94+Podcast+Player) 👈
+👉 [Open Handbook](https://autocubes.site/junior-notes/rs-bootcamp-2026/readme) 👈
 
 This handbook is currently in a test phase.
 If you notice any issues or have suggestions, feel free to contact me on Discord: `@OreskaG`

--- a/stage0.5 Bootcamp/tasks/shelter/shelter-part1.md
+++ b/stage0.5 Bootcamp/tasks/shelter/shelter-part1.md
@@ -6,7 +6,7 @@
 
 ## Our Handbook
 
-👉 [Open Handbook](https://publish.obsidian.md/juniornotess/RS-Bootcamp-2026/Tasks/02a+%E2%80%94+Shelter+Part+1+%E2%80%94+Fixed+Layout) 👈
+👉 [Open Handbook](https://autocubes.site/junior-notes/rs-bootcamp-2026/readme) 👈
 
 This handbook is currently in a test phase.
 If you notice any issues or have suggestions, feel free to contact me on Discord: `@OreskaG`

--- a/stage0.5 Bootcamp/tasks/shelter/shelter-part2.md
+++ b/stage0.5 Bootcamp/tasks/shelter/shelter-part2.md
@@ -6,7 +6,7 @@
 
 ## Our Handbook
 
-👉 [Open Handbook](https://publish.obsidian.md/juniornotess/RS-Bootcamp-2026/Tasks/02b+%E2%80%94+Shelter+Part+2+%E2%80%94+Responsive) 👈
+👉 [Open Handbook](https://autocubes.site/junior-notes/rs-bootcamp-2026/readme) 👈
 
 This handbook is currently in a test phase.
 If you notice any issues or have suggestions, feel free to contact me on Discord: `@OreskaG`

--- a/stage0.5 Bootcamp/tasks/shelter/shelter-part3.md
+++ b/stage0.5 Bootcamp/tasks/shelter/shelter-part3.md
@@ -6,7 +6,7 @@
 
 ## Our Handbook
 
-👉 [Open Handbook](https://publish.obsidian.md/juniornotess/RS-Bootcamp-2026/Tasks/02c+%E2%80%94+Shelter+Part+3+%E2%80%94+JavaScript) 👈
+👉 [Open Handbook](https://autocubes.site/junior-notes/rs-bootcamp-2026/readme) 👈
 
 This handbook is currently in a test phase.
 If you notice any issues or have suggestions, feel free to contact me on Discord: `@OreskaG`

--- a/stage0.5 Bootcamp/tasks/shelter/shelter.md
+++ b/stage0.5 Bootcamp/tasks/shelter/shelter.md
@@ -6,7 +6,7 @@
 
 ## Our Handbook
 
-👉 [Open Handbook](<https://publish.obsidian.md/juniornotess/RS-Bootcamp-2026/Tasks/02+%E2%80%94+Shelter+(%D0%BE%D0%B1%D0%B7%D0%BE%D1%80)>) 👈
+👉 [Open Handbook](https://autocubes.site/junior-notes/rs-bootcamp-2026/readme) 👈
 
 This handbook is currently in a test phase.
 If you notice any issues or have suggestions, feel free to contact me on Discord: `@OreskaG`


### PR DESCRIPTION
## Summary
- replace the old Obsidian Publish handbook links in Stage 0.5 Bootcamp tasks with the new autocubes.site URL

## Checks
- verified https://autocubes.site/junior-notes/rs-bootcamp-2026/readme returns 200