### PR TITLE
Generalize Podcast Player task for multiple APIs

### DIFF
--- a/stage0.5 Bootcamp/tasks/podcast-player/README.md
+++ b/stage0.5 Bootcamp/tasks/podcast-player/README.md
@@ -160,18 +160,18 @@ The reviewer goes through every scoring criterion and awards the listed points o
 
 ### Section 1 - Landing page and search (40 points)
 
-- The landing page loads and renders a list of podcasts fetched from the [Best Podcasts API](https://www.listennotes.com/api/docs/) (`GET /best_podcasts`, `sort=recent_published_first`) **+10**
+- The landing page loads and renders a list of podcasts fetched from the selected podcast API **+10**
 - Each podcast tile shows at least: cover image, title, author/feed name **+5**
 - A search input is present on the landing page **+5**
-- When the search input is empty, podcasts from `GET /best_podcasts` are shown **+5**
-- When the search input has a value, a request is sent to the [Search API](https://www.listennotes.com/api/docs/) (`GET /search?q=<query>&type=podcast`) and the response is rendered **+5**
+- When the search input is empty, the default podcast list is shown **+5**
+- When the search input has a value, search results are displayed **+5**
 - Search requests are debounced or throttled (verified by observing network requests in DevTools while typing) **+5**
 - A loading indicator is shown while a request is in flight **+5**
 
 ### Section 2 - Podcast details page (25 points)
 
 - Clicking a podcast tile navigates to a details page for that podcast **+5**
-- The details page lists episodes from the [Podcast Details API](https://www.listennotes.com/api/docs/) (`GET /podcasts/{id}`) **+10**
+- The details page lists episodes for the selected podcast **+10**
 - Each episode item shows at least: title, publication date, duration **+5**
 - An in-app control returns the user to the landing page without using the browser's "Back" button **+5**
 

--- a/stage0.5 Bootcamp/tasks/podcast-player/cross-check.json
+++ b/stage0.5 Bootcamp/tasks/podcast-player/cross-check.json
@@ -4,7 +4,7 @@
     { "type": "title", "title": "Section 1 - Landing page and search" },
     {
       "type": "subtask",
-      "text": "Landing page loads and renders a list of podcasts fetched from the Best Podcasts API (GET /best_podcasts, sort=recent_published_first)",
+      "text": "Landing page loads and renders a list of podcasts fetched from the selected podcast API",
       "max": 10
     },
     {
@@ -19,12 +19,12 @@
     },
     {
       "type": "subtask",
-      "text": "When the search input is empty, podcasts from GET /best_podcasts are shown",
+      "text": "When the search input is empty, the default podcast list is shown",
       "max": 5
     },
     {
       "type": "subtask",
-      "text": "When the search input has a value, a request is sent to the Search API (GET /search?q=<query>&type=podcast) and the response is rendered",
+      "text": "When the search input has a value, search results are displayed",
       "max": 5
     },
     {
@@ -46,7 +46,7 @@
     },
     {
       "type": "subtask",
-      "text": "Details page lists episodes from the Podcast Details API (GET /podcasts/{id})",
+      "text": "The details page lists episodes for the selected podcast",
       "max": 10
     },
     {


### PR DESCRIPTION
#### Generalize Podcast Player task for multiple APIs

<!-- ✍️ Provide a concise and informative title for your pull request -->

#### 🤔 This is a

- [ ] 🌟 New task
- [ ] 🌐 New module
- [x] ⚙️ Update to an existing task
- [ ] 🔧 Update to an existing module
- [ ] 🔗 Update or addition of external resources or links
- [x] 🐛 Fix in a task or related content
- [ ] 🛠 Fix in a module or related content
- [ ] ✏️ Fixed a typo or grammatical error
- [ ] 🔗 Fixed a broken link
- [ ] ❓ Other (specify: **\*\*\*\***\_\_\_\_**\*\*\*\***)

#### Description

- **Brief Overview:**

  Updated the Podcast Player task to make it API-agnostic. The task description and scoring criteria no longer require a specific podcast API, allowing students to use any compatible API while keeping the same functional requirements.

- **Implementation Approach:**

  - Generalized the scoring criteria to remove references to specific Listen Notes endpoints.
  - Updated the task description to clarify that any podcast API may be used.
  - Kept the Listen Notes test API as the example implementation in the documentation.

#### Additional Information

- **Screenshots/Links:**

  Previous related PR: #1989

#### Checklist

- [x] ✅ I have performed a self-review of my own code.
- [ ] 📝 I have commented my code, particularly in hard-to-understand areas.
- [x] 🔧 I have made corresponding changes to the documentation (if applicable).
- [x] 🚫 My changes generate no new warnings or errors.